### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,11 +6,6 @@ plugins {
     id("org.danilopianini.git-sensitive-semantic-versioning")
 }
 
-
-gitSemVer {
-    version = computeGitSemVer()
-}
-
 allprojects {
     group = "org.danilopianini"
 }

--- a/versions.properties
+++ b/versions.properties
@@ -1,4 +1,4 @@
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.